### PR TITLE
Updated Fluent Devnet Explorer Links in Developer Guides

### DIFF
--- a/developer-guides/developer-quickstart-guide/rust-developer-guide.md
+++ b/developer-guides/developer-quickstart-guide/rust-developer-guide.md
@@ -106,4 +106,4 @@ node deploy-contract.js --dev ../bin/greeting.wasm
 
 Upon successful deployment, the receipt of your deployment transaction will be displayed, confirming the smart contract deployment on Fluent using the Fluent SDK.
 
-To view your deployed Fluent contract, navigate to the [Fluent Devnet Explorer.](https://blockscout.dev.thefluent.xyz/) From there, you can input your token address to explore your deployed contract.
+To view your deployed Fluent contract, navigate to the [Fluent Devnet Explorer.](https://blockscout.dev.gblend.xyz/) From there, you can input your token address to explore your deployed contract.

--- a/developer-guides/developer-quickstart-guide/solidity-developer-guide.md
+++ b/developer-guides/developer-quickstart-guide/solidity-developer-guide.md
@@ -143,4 +143,4 @@ npm run deploy
 # Token address:
 ```
 
-To view your deployed contract on Fluent, navigate to the [Fluent Devnet Explorer](https://blockscout.dev.thefluent.xyz/). From there, you can input your token address to explore your deployed contract.
+To view your deployed contract on Fluent, navigate to the [Fluent Devnet Explorer](https://blockscout.dev.gblend.xyz/). From there, you can input your token address to explore your deployed contract.

--- a/developer-guides/developer-quickstart-guide/vyper-developer-guide.md
+++ b/developer-guides/developer-quickstart-guide/vyper-developer-guide.md
@@ -143,4 +143,4 @@ npm run deploy-vyper
 # Token address:
 ```
 
-To view your deployed Fluent contract, navigate to the [Fluent Devnet Explorer](https://blockscout.dev.thefluent.xyz/). From there, you can input your token address to explore your deployed contract.
+To view your deployed Fluent contract, navigate to the [Fluent Devnet Explorer](https://blockscout.dev.gblend.xyz/). From there, you can input your token address to explore your deployed contract.


### PR DESCRIPTION
### **Description:**

Replaced outdated Fluent Devnet Explorer links with the correct URL to ensure developers are directed to the correct Blockscout instance.

**Files Updated:**

- `developer-guides/developer-quickstart-guide/rust-developer-guide.md`
- `developer-guides/developer-quickstart-guide/solidity-developer-guide.md`
- `developer-guides/developer-quickstart-guide/vyper-developer-guide.md`

**Changes:**

- Updated **Fluent Devnet Explorer** link from `https://blockscout.dev.thefluent.xyz/` (old) to `https://blockscout.dev.gblend.xyz/` (new, working).